### PR TITLE
re: 회원가입 완료 시 헤더 UI 변경 및 프로필 이미지 등록 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@tanstack/react-query": "^5.62.16",
         "@tanstack/react-query-devtools": "^5.62.16",
         "axios": "^1.7.9",
@@ -914,6 +915,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-free": {
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
@@ -921,6 +932,32 @@
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4245,7 +4282,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4736,7 +4772,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4877,7 +4912,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-quill": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
-    "@fortawesome/react-fontawesome": "^0.2.2",
     "@tanstack/react-query": "^5.62.16",
     "@tanstack/react-query-devtools": "^5.62.16",
     "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@tanstack/react-query": "^5.62.16",
     "@tanstack/react-query-devtools": "^5.62.16",
     "axios": "^1.7.9",

--- a/src/components/layouts/menuIcon.jsx
+++ b/src/components/layouts/menuIcon.jsx
@@ -1,12 +1,15 @@
 import useUserStore from "@store/userStore";
+import { useNavigate } from "react-router-dom";
 
 const MenuIcons = () => {
   const { user, resetUser } = useUserStore();
+  const navigate = useNavigate();
 
   const handleLogout = (e) => {
     e.preventDefault();
     resetUser();
     alert(`${user.name} 님, 정상적으로 로그아웃 되었습니다.`);
+    navigate("/");
   };
 
   return (

--- a/src/components/layouts/menuIcon.jsx
+++ b/src/components/layouts/menuIcon.jsx
@@ -24,7 +24,7 @@ const MenuIcons = () => {
           </a>
           {user.profile && (
             <img
-              className="w-12 h-12 rounded-full object-contain"
+              className="w-12 h-12 rounded-full object-cover"
               src={`https://11.fesp.shop${user.profile}`}
               alt="프로필 이미지"
             />

--- a/src/components/layouts/menuIcon.jsx
+++ b/src/components/layouts/menuIcon.jsx
@@ -10,33 +10,49 @@ const MenuIcons = () => {
   };
 
   return (
-    <div className="absolute top-4 right-6 flex space-x-8 items-center">
+    <div className="absolute top-4 right-6 flex space-x-6 items-center">
       {user ? (
-        <form className="flex gap-[20px]" onSubmit={handleLogout}>
-          <p className="flex items-center"> {user.name} 님 :)</p>
+        <form className="flex gap-[20px] items-center" onSubmit={handleLogout}>
+          <a href="/order" className="text-gray-700 hover:text-primary-30">
+            <i className="fas fa-user"></i>
+          </a>
+          <a href="/cart" className="text-gray-700 hover:text-primary-30">
+            <i className="fas fa-shopping-cart"></i>
+          </a>
+          <a href="/search" className="text-gray-700 hover:text-primary-30">
+            <i className="fas fa-search mr-2"></i>
+          </a>
+          {user.profile && (
+            <img
+              className="w-12 h-12 rounded-full object-contain"
+              src={`https://11.fesp.shop${user.profile}`}
+              alt="프로필 이미지"
+            />
+          )}
+          <p> {user.name} 님 :)</p>
           <button
             type="submit"
-            className="bg-secondary-20 py-2 px-4 text-white ml-2 hover:bg-secondary-10 rounded font-gowunBold"
+            className="bg-primary-40 py-2 px-4 text-white hover:bg-primary-20 rounded font-gowunBold"
           >
             로그아웃
           </button>
         </form>
       ) : (
         <>
+          <a href="/search" className="text-gray-700 hover:text-primary-30">
+            <i className="fas fa-search mr-2"></i>
+          </a>
           <a
             href="/login"
-            className="bg-primary-40 px-4 py-2 rounded text-white hover:text-primary-20 font-gowunBold"
+            className="bg-primary-40 px-4 py-2 rounded text-white hover:bg-primary-20 font-gowunBold"
           >
             로그인
           </a>
-          <a href="/profile" className="text-gray-700 hover:text-secondary">
-            <i className="fas fa-user"></i>
-          </a>
-          <a href="/cart" className="text-gray-700 hover:text-secondary">
-            <i className="fas fa-shopping-cart"></i>
-          </a>
-          <a href="/search" className="text-gray-700 hover:text-secondary">
-            <i className="fas fa-search"></i>
+          <a
+            href="/signup"
+            className="bg-secondary-20 px-4 py-2 rounded text-white hover:bg-secondary-10 font-gowunBold"
+          >
+            회원가입
           </a>
         </>
       )}

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -28,7 +28,7 @@ function Login() {
       setUser({
         _id: user._id,
         name: user.name,
-        profile: user.image.path,
+        profile: user.image?.path,
         accessToken: user.token.accessToken,
         refreshToken: user.token.refreshToken,
       });

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -28,6 +28,7 @@ function Login() {
       setUser({
         _id: user._id,
         name: user.name,
+        profile: user.image.path,
         accessToken: user.token.accessToken,
         refreshToken: user.token.refreshToken,
       });

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -17,7 +17,7 @@ function Login() {
     setError,
     formState: { errors },
   } = useForm({
-    defaultValues: { email: "u1@market.com", password: "11111111" },
+    defaultValues: { email: "y40@market.com", password: "11111111" },
   });
 
   const login = useMutation({

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -19,7 +19,7 @@ function Myorder() {
         <div className="flex-grow min-w-0 basis-0 flex flex-col gap-[40px]">
           <div className="flex items-center justify-center gap-[30px] box-border p-[30px] overflow-hidden">
             <div className="w-[700px] flex items-start gap-[20px]">
-              {user?.profile ? (
+              {user.profile ? (
                 <img
                   className="w-[100px] h-[100px] aspect-square object-cover border border-grey-40 rounded-full box-border p-1"
                   src={`https://11.fesp.shop${user.profile}`}
@@ -31,7 +31,7 @@ function Myorder() {
                   src="/icons/profile.svg"
                 />
               )}
-              <p>{user?.name}님, 안녕하세요.</p>
+              <p>{user.name}님, 안녕하세요.</p>
             </div>
 
             <div className="flex gap-[20px]">

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -1,4 +1,8 @@
+import useUserStore from "@store/userStore";
+
 function Myorder() {
+  const { user } = useUserStore();
+
   return (
     <>
       <div className="flex box-border max-w-[1200px] mx-auto px-6">
@@ -13,13 +17,21 @@ function Myorder() {
         </div>
 
         <div className="flex-grow min-w-0 basis-0 flex flex-col gap-[40px]">
-          <div className="flex items-center justify-center gap-[30px] box-border p-[60px] overflow-hidden">
-            <div className="w-[700px] flex items-start gap-[10px]">
-              <img
-                className="w-[100px] aspect-square object-contain"
-                src="/icons/profile.svg"
-              />
-              <p>이지영님 안녕하세요.</p>
+          <div className="flex items-center justify-center gap-[30px] box-border p-[30px] overflow-hidden">
+            <div className="w-[700px] flex items-start gap-[20px]">
+              {user?.profile ? (
+                <img
+                  className="w-[100px] h-[100px] aspect-square object-cover border border-grey-40 rounded-full box-border p-1"
+                  src={`https://11.fesp.shop${user.profile}`}
+                  alt="프로필 이미지"
+                />
+              ) : (
+                <img
+                  className="w-[100px] aspect-square object-contain"
+                  src="/icons/profile.svg"
+                />
+              )}
+              <p>{user?.name}님, 안녕하세요.</p>
             </div>
 
             <div className="flex gap-[20px]">

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -21,7 +21,7 @@ function Myorder() {
             <div className="w-[700px] flex items-start gap-[20px]">
               {user.profile ? (
                 <img
-                  className="w-[100px] h-[100px] aspect-square object-cover border border-grey-40 rounded-full box-border p-1"
+                  className="w-[100px] h-[100px] aspect-square object-cover border border-grey-20 rounded-full box-border p-1"
                   src={`https://11.fesp.shop${user.profile}`}
                   alt="프로필 이미지"
                 />

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -165,17 +165,10 @@ function Signup() {
                 )}
 
                 <div
-                  className="absolute bottom-1 right-0 rounded-full border border-grey-30 bg-white p-2 cursor-pointer"
+                  className="absolute bottom-1 right-0 rounded-full border border-grey-30 bg-white p-2 cursor-pointer "
                   onClick={handleOpen}
                 >
-                  <button
-                    type="button"
-                    className={`${styles.camera}`}
-                    onClick={(e) => {
-                      e.stopPropagation(); // 이벤트 버블링 방지
-                      handleOpen();
-                    }}
-                  >
+                  <button type="button" className={`${styles.camera}`}>
                     {isOpen && (
                       <div className="absolute left-6 top-full mt-1 p-2 shadow rounded-lg flex flex-col gap-[8px] bg-white">
                         <label
@@ -199,8 +192,8 @@ function Signup() {
                         </label>
                         <div
                           className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer"
-                          onClick={(e) => {
-                            e.stopPropagation();
+                          onClick={() => {
+                            // e.stopPropagation();
                             handleClearFile();
                           }}
                         >

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -23,6 +23,7 @@ function Signup() {
 
   const axios = useAxiosInstance();
   const navigate = useNavigate();
+  const setUser = useUserStore((store) => store.setUser);
 
   const registerUser = useMutation({
     mutationFn: (userInfo) => {
@@ -32,7 +33,20 @@ function Signup() {
       console.log("Final userInfo: ", userInfo);
       return axios.post(`/users`, userInfo);
     },
-    onSuccess: () => {
+    onSuccess: async (res, userInfo) => {
+      const user = res.data.item;
+      console.log(user); // password 속성 존재 (undefined X)
+      user.password = userInfo.password; // 굳이 해줄 필요? (안 쓰면 422 에러)
+      console.log(user); // password 속성 당연히 존재
+
+      const userLogin = await axios.post(`/users/login`, user);
+      setUser({
+        _id: userLogin._id,
+        name: userLogin.name,
+        accessToken: userLogin.token.accessToken,
+        refreshToken: user.token.refreshToken,
+      });
+
       alert("회원가입이 완료되었습니다.");
       navigate("/");
     },

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -11,11 +11,17 @@ const emailExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 function Signup() {
   // Dropdown
-  // const [isOpen, setIsOpen] = useState(false);
-  // const handleOpen = () => {
-  //   setIsOpen(!isOpen);
-  // };
-  // const inputFileRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleClearFile = () => {
+    setProfileImage(undefined);
+    console.log(watch().attach);
+    setValue("attach", []);
+    console.log(watch().attach);
+  };
 
   const {
     register,
@@ -23,6 +29,7 @@ function Signup() {
     setError,
     formState: { errors },
     watch,
+    setValue,
   } = useForm({
     mode: "onSubmit",
     reValidateMode: "onChange",
@@ -59,18 +66,15 @@ function Signup() {
       // ** createObjectURL로 생성한 URL은 브라우저에서만 유효하고, 파일을 서버로 전송하려면 FormData 등을 사용해야 함 **
       setProfileImage(newImageUrl);
     }
+    setIsOpen(false);
   };
-
-  // const handleDelete = () => {
-  //   setProfileImage("");
-  // };
 
   const registerUser = useMutation({
     mutationFn: async (userInfo) => {
       console.log("Initial userInfo: ", userInfo); // name, email, password, password-confirm, attach 정보가 담긴 객체
 
       // 프로필 이미지 등록 로직 구현
-      if (userInfo.attach.length > 0) {
+      if (userInfo.attach?.length > 0) {
         const profileFormData = new FormData();
         profileFormData.append("attach", userInfo.attach[0]); // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
 
@@ -101,7 +105,7 @@ function Signup() {
       setUser({
         _id: userLogin._id,
         name: userLogin.name,
-        profile: userLogin.image.path,
+        profile: userLogin.image?.path,
         accessToken: userLogin.token.accessToken,
         refreshToken: userLogin.token.refreshToken,
       });
@@ -160,25 +164,53 @@ function Signup() {
                 ) : (
                   <div className="w-full h-full bg-[url('./icons/profile.svg')]"></div>
                 )}
-                <div className="absolute bottom-1 right-0 rounded-full border border-grey-30 bg-white p-2 cursor-pointer">
-                  <label htmlFor="attach">
-                    <img
-                      src="/icons/camera.svg"
-                      alt="이미지 첨부"
-                      className="cursor-pointer"
-                    />
-                  </label>
-                  <input
-                    type="file"
-                    id="attach"
-                    accept="image/*"
-                    className="hidden"
-                    {...register("attach", {
-                      // handleFileShow는 미리보기 UI만 담당하고, 실제 폼 데이터 관리는 register()에 맡긴다! (=> 굳이 setValue로 attach속성 값을 직접 설정할 필요 없다.)
-                      // ∵ register()가 이미 파일 데이터를 관리하고 있는데, setValue로 다시 값을 설정하려고 하면 두 방식이 충돌하여 가입하기 버튼 눌렀을 시, api요청이 정상적으로 이루어지지 않음.
-                      onChange: (e) => handleFileShow(e),
-                    })}
-                  />
+
+                <div
+                  className="absolute bottom-1 right-0 rounded-full border border-grey-30 bg-white p-2 cursor-pointer"
+                  onClick={handleOpen}
+                >
+                  <button
+                    type="button"
+                    className={`${styles.camera}`}
+                    onClick={(e) => {
+                      e.stopPropagation(); // 이벤트 버블링 방지
+                      handleOpen();
+                    }}
+                  >
+                    {isOpen && (
+                      <div className="absolute left-6 top-full mt-1 p-2 shadow rounded-lg flex flex-col gap-[8px] bg-white">
+                        <label
+                          className="flex items-center gap-[10px] p-2 pr-8 hover:bg-sky-100 rounded cursor-pointer"
+                          htmlFor="attach"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <i className="fa-solid fa-pen"></i>
+                          <span className="whitespace-nowrap">등록</span>
+                          <input
+                            type="file"
+                            id="attach"
+                            accept="image/*"
+                            className="hidden"
+                            {...register("attach", {
+                              onChange: (e) => {
+                                handleFileShow(e);
+                              },
+                            })}
+                          />
+                        </label>
+                        <div
+                          className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleClearFile();
+                          }}
+                        >
+                          <i className="fa-regular fa-trash-can"></i>
+                          <span className="whitespace-nowrap">삭제</span>
+                        </div>
+                      </div>
+                    )}
+                  </button>
                 </div>
               </div>
 

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -192,10 +192,7 @@ function Signup() {
                         </label>
                         <div
                           className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer"
-                          onClick={() => {
-                            // e.stopPropagation();
-                            handleClearFile();
-                          }}
+                          onClick={handleClearFile}
                         >
                           <i className="fa-regular fa-trash-can"></i>
                           <span className="whitespace-nowrap">삭제</span>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -192,10 +192,7 @@ function Signup() {
                         </label>
                         <div
                           className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer"
-                          onClick={() => {
-                            // e.stopPropagation();
-                            handleClearFile();
-                          }}
+                          onClick={handleClearFile()}
                         >
                           <i className="fa-regular fa-trash-can"></i>
                           <span className="whitespace-nowrap">삭제</span>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -35,8 +35,8 @@ function Signup() {
     reValidateMode: "onChange",
     criteriaMode: "all",
     defaultValues: {
-      name: "여름",
-      email: "y20@market.com",
+      name: "김마켓",
+      email: "kimarket2@market.com",
       password: 11111111,
       "password-confirm": 11111111,
     },
@@ -225,7 +225,7 @@ function Signup() {
                     id="name"
                     type="text"
                     placeholder="이름"
-                    className={`${styles.inputUnset}`}
+                    className={`${styles.inputUnset} ${styles.inputCustom}`}
                     {...register("name", {
                       required: "이름은 필수입니다.",
                       minLength: {
@@ -253,7 +253,7 @@ function Signup() {
                       id="email"
                       type="email"
                       placeholder="이메일"
-                      className={`${styles.inputUnset}`}
+                      className={`${styles.inputUnset} ${styles.inputCustom}`}
                       {...register("email", {
                         required: "이메일은 필수입니다.",
                         pattern: {
@@ -277,7 +277,7 @@ function Signup() {
                       id="password"
                       type="password"
                       placeholder="비밀번호"
-                      className={`${styles.inputUnset}`}
+                      className={`${styles.inputUnset} ${styles.inputCustom}`}
                       {...register("password", {
                         required: "비밀번호는 필수입니다.",
                         minLength: {
@@ -301,7 +301,7 @@ function Signup() {
                       id="password-confirm"
                       type="password"
                       placeholder="비밀번호 확인"
-                      className={`${styles.inputUnset}`}
+                      className={`${styles.inputUnset} ${styles.inputCustom}`}
                       {...register("password-confirm", {
                         required: "비밀번호 확인은 필수입니다.",
                         validate: (value) =>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -5,17 +5,17 @@ import useAxiosInstance from "@hooks/useAxiosInstance";
 import ErrorMsg from "@components/ErrorMsg";
 import { useNavigate } from "react-router-dom";
 import useUserStore from "@store/userStore";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 const emailExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 function Signup() {
   // Dropdown
-  const [isOpen, setIsOpen] = useState(false);
-  const handleOpen = () => {
-    setIsOpen(!isOpen);
-  };
-  const inputFileRef = useRef(null);
+  // const [isOpen, setIsOpen] = useState(false);
+  // const handleOpen = () => {
+  //   setIsOpen(!isOpen);
+  // };
+  // const inputFileRef = useRef(null);
 
   const {
     register,
@@ -60,9 +60,9 @@ function Signup() {
     }
   };
 
-  const handleDelete = () => {
-    setProfileImage("");
-  };
+  // const handleDelete = () => {
+  //   setProfileImage("");
+  // };
 
   const registerUser = useMutation({
     mutationFn: async (userInfo) => {
@@ -159,43 +159,22 @@ function Signup() {
                 ) : (
                   <div className="w-full h-full bg-[url('./icons/profile.svg')]"></div>
                 )}
-
-                <div className="absolute bottom-[4px] right-0 rounded-full border border-grey-30 bg-white hover:bg-grey-5">
-                  <button
-                    type="button"
-                    className={`box-border w-12 h-12 ${styles.camera} `}
-                    onClick={handleOpen}
-                  >
-                    {isOpen && (
-                      <ul className="absolute left-6 top-full mt-1 p-2 shadow rounded-lg flex flex-col gap-[8px] bg-white">
-                        <li
-                          className="flex items-center gap-[10px] p-2 pr-8 hover:bg-sky-100 rounded cursor-pointer"
-                          onClick={() => inputFileRef.current.click()}
-                        >
-                          <i className="fa-solid fa-pen"></i>
-                          <span className="whitespace-nowrap">등록</span>
-                        </li>
-                        <li
-                          className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer"
-                          onClick={handleDelete}
-                        >
-                          <i className="fa-regular fa-trash-can"></i>
-                          <span className="whitespace-nowrap">삭제</span>
-                        </li>
-                      </ul>
-                    )}
-                    <input
-                      type="file"
-                      id="attach"
-                      accept="image/*"
-                      className="hidden"
-                      {...register("attach")}
-                      onChange={(e) => {
-                        handleFileChange(e);
-                      }}
-                      ref={inputFileRef}
+                <div className="absolute bottom-1 right-0 rounded-full border border-grey-30 bg-white p-2 cursor-pointer">
+                  <label htmlFor="attach">
+                    <img
+                      src="/icons/camera.svg"
+                      alt="이미지 첨부"
+                      className="cursor-pointer"
                     />
-                  </button>
+                  </label>
+                  <input
+                    type="file"
+                    id="attach"
+                    accept="image/*"
+                    className="hidden"
+                    {...register("attach")} // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
+                    onChange={handleFileChange}
+                  />
                 </div>
               </div>
 

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -38,9 +38,9 @@ function Signup() {
   const axios = useAxiosInstance();
   const navigate = useNavigate();
   const setUser = useUserStore((store) => store.setUser);
-  const [profileImage, setProfileImage] = useState("");
+  const [profileImage, setProfileImage] = useState();
 
-  const handleFileChange = (e) => {
+  const handleFileShow = (e) => {
     const file = e.target.files[0]; // 사용자가 업로드한 파일
     console.log("file: ", file);
     const watchAll = watch();
@@ -55,6 +55,7 @@ function Signup() {
 
       // 새로운 URL 생성
       const newImageUrl = URL.createObjectURL(file); // 이미지 파일 미리보기 위해 파일 객체를 URL로 변환
+      console.log(newImageUrl);
       // ** createObjectURL로 생성한 URL은 브라우저에서만 유효하고, 파일을 서버로 전송하려면 FormData 등을 사용해야 함 **
       setProfileImage(newImageUrl);
     }
@@ -69,7 +70,7 @@ function Signup() {
       console.log("Initial userInfo: ", userInfo); // name, email, password, password-confirm, attach 정보가 담긴 객체
 
       // 프로필 이미지 등록 로직 구현
-      if (userInfo.attach?.length > 0) {
+      if (userInfo.attach.length > 0) {
         const profileFormData = new FormData();
         profileFormData.append("attach", userInfo.attach[0]); // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
 
@@ -172,8 +173,11 @@ function Signup() {
                     id="attach"
                     accept="image/*"
                     className="hidden"
-                    {...register("attach")} // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
-                    onChange={handleFileChange}
+                    {...register("attach", {
+                      // handleFileShow는 미리보기 UI만 담당하고, 실제 폼 데이터 관리는 register()에 맡긴다! (=> 굳이 setValue로 attach속성 값을 직접 설정할 필요 없다.)
+                      // ∵ register()가 이미 파일 데이터를 관리하고 있는데, setValue로 다시 값을 설정하려고 하면 두 방식이 충돌하여 가입하기 버튼 눌렀을 시, api요청이 정상적으로 이루어지지 않음.
+                      onChange: (e) => handleFileShow(e),
+                    })}
                   />
                 </div>
               </div>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -4,6 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import useAxiosInstance from "@hooks/useAxiosInstance";
 import ErrorMsg from "@components/ErrorMsg";
 import { useNavigate } from "react-router-dom";
+import useUserStore from "@store/userStore";
 
 const emailExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -5,6 +5,7 @@ import useAxiosInstance from "@hooks/useAxiosInstance";
 import ErrorMsg from "@components/ErrorMsg";
 import { useNavigate } from "react-router-dom";
 import useUserStore from "@store/userStore";
+import { useState } from "react";
 
 const emailExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
@@ -31,6 +32,22 @@ function Signup() {
   const axios = useAxiosInstance();
   const navigate = useNavigate();
   const setUser = useUserStore((store) => store.setUser);
+  const [profileImage, setProfileImage] = useState();
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0]; // 사용자가 업로드한 파일
+    if (file) {
+      // 이전 URL 정리
+      if (profileImage) {
+        URL.revokeObjectURL(profileImage);
+      }
+
+      // 새로운 URL 생성
+      const newImageUrl = URL.createObjectURL(file); // 이미지 파일 미리보기 위해 파일 객체를 URL로 변환
+      // ** createObjectURL로 생성한 URL은 브라우저에서만 유효하고, 파일을 서버로 전송하려면 FormData 등을 사용해야 함 **
+      setProfileImage(newImageUrl);
+    }
+  };
 
   const registerUser = useMutation({
     mutationFn: async (userInfo) => {
@@ -117,18 +134,29 @@ function Signup() {
               <div
                 id="fildupload_profile_img"
                 className="relative mx-auto w-[100px] h-[100px]"
-                accept="image/jepg, image/jpg, image/png, image/gif, image/svg+xml"
               >
-                <div className="w-full h-full bg-[url('./icons/profile.svg')] bg-cover bg-center"></div>
+                {profileImage ? (
+                  <img
+                    src={profileImage}
+                    alt="프로필사진 미리보기"
+                    className="w-full h-full border border-grey-20 rounded-full object-cover p-1"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-[url('./icons/profile.svg')]"></div>
+                )}
 
                 <div className="absolute bottom-[4px] right-0 rounded-full border border-grey-30 bg-white cursor-pointer">
-                  <button className={`box-border w-12 h-12 ${styles.camera}`}>
+                  <button
+                    type="button"
+                    className={`box-border w-12 h-12 ${styles.camera}`}
+                  >
                     <input
                       type="file"
                       id="attach"
                       accept="image/*"
                       className={`${styles.hidden}`}
                       {...register("attach")} // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
+                      onChange={handleFileChange}
                     />
                   </button>
                 </div>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -18,9 +18,8 @@ function Signup() {
 
   const handleClearFile = () => {
     setProfileImage(undefined);
-    console.log(watch().attach);
     setValue("attach", []);
-    console.log(watch().attach);
+    handleOpen();
   };
 
   const {

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -110,9 +110,7 @@ function Signup() {
                 <div className="w-full h-full bg-[url('./icons/profile.svg')] bg-cover bg-center"></div>
 
                 <div className="absolute bottom-[4px] right-0 rounded-full border border-grey-30 bg-white cursor-pointer">
-                  <button
-                    className={`box-border w-12 h-12 ${styles.camera} cursor-pointer`}
-                  >
+                  <button className={`box-border w-12 h-12 ${styles.camera}`}>
                     <input
                       type="file"
                       id="attach"
@@ -151,7 +149,6 @@ function Signup() {
                 </div>
                 <ErrorMsg target={errors.name} />
               </div>
-
               <div className="id-collection">
                 <div>
                   <div
@@ -224,7 +221,6 @@ function Signup() {
                   <ErrorMsg target={errors["password-confirm"]} />
                 </div>
               </div>
-
               <button className="font-gowunBold w-full h-[48px] rounded-2xl text-center cursor-pointer box-border text-[18px] text-white bg-primary-40 focus:bg-primary-30">
                 가입하기
               </button>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -19,6 +19,12 @@ function Signup() {
     mode: "onSubmit",
     reValidateMode: "onChange",
     criteriaMode: "all",
+    defaultValues: {
+      name: "여름",
+      email: "y20@market.com",
+      password: 11111111,
+      "password-confirm": 11111111,
+    },
   });
   console.log(errors);
 
@@ -33,7 +39,7 @@ function Signup() {
       // 프로필 이미지 등록 로직 구현
       if (userInfo.attach.length > 0) {
         const profileFormData = new FormData();
-        profileFormData.append("attach", userInfo.attach[0]);
+        profileFormData.append("attach", userInfo.attach[0]); // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
 
         const fileRes = await axios.post("/files", profileFormData, {
           headers: { "Content-Type": "multipart/form-data" },
@@ -53,12 +59,18 @@ function Signup() {
       user.password = userInfo.password; // 굳이 해줄 필요? (안 쓰면 422 에러)
       console.log(user); // password 속성 당연히 존재
 
-      const userLogin = await axios.post(`/users/login`, user);
+      // 로그인 요청
+      const resLogin = await axios.post(`/users/login`, user);
+      const userLogin = resLogin.data.item;
+      delete userLogin["password-confirm"]; // 보안상 비밀번호 확인을 지움.
+      console.log(userLogin);
+
       setUser({
         _id: userLogin._id,
         name: userLogin.name,
+        profile: userLogin.image.path,
         accessToken: userLogin.token.accessToken,
-        refreshToken: user.token.refreshToken,
+        refreshToken: userLogin.token.refreshToken,
       });
 
       alert("회원가입이 완료되었습니다.");
@@ -116,7 +128,7 @@ function Signup() {
                       id="attach"
                       accept="image/*"
                       className={`${styles.hidden}`}
-                      {...register("attach")} // files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
+                      {...register("attach")} // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
                     />
                   </button>
                 </div>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -27,8 +27,21 @@ function Signup() {
   const setUser = useUserStore((store) => store.setUser);
 
   const registerUser = useMutation({
-    mutationFn: (userInfo) => {
+    mutationFn: async (userInfo) => {
       console.log("Initial userInfo: ", userInfo); // name, email, password, password-confirm 정보가 담긴 객체
+
+      // 프로필 이미지 등록 로직 구현
+      if (userInfo.attach.length > 0) {
+        const profileFormData = new FormData();
+        profileFormData.append("attach", userInfo.attach[0]);
+
+        const fileRes = await axios.post("/files", profileFormData, {
+          headers: { "Content-Type": "multipart/form-data" },
+        });
+
+        userInfo.image = fileRes.data.item[0];
+        delete userInfo.attach;
+      }
 
       userInfo.type = "user";
       console.log("Final userInfo: ", userInfo);
@@ -96,11 +109,16 @@ function Signup() {
               >
                 <div className="w-full h-full bg-[url('./icons/profile.svg')] bg-cover bg-center"></div>
 
-                <div className="absolute bottom-[4px] right-0 rounded-full  border border-grey-30">
-                  <button className="box-border w-10 h-10 bg-white rounded-full cursor-pointer">
-                    <img
-                      className="w-7 h-7 mx-auto mt-1"
-                      src="/icons/camera.svg"
+                <div className="absolute bottom-[4px] right-0 rounded-full border border-grey-30 bg-white cursor-pointer">
+                  <button
+                    className={`box-border w-12 h-12 ${styles.camera} cursor-pointer`}
+                  >
+                    <input
+                      type="file"
+                      id="attach"
+                      accept="image/*"
+                      className={`${styles.hidden}`}
+                      {...register("attach")} // files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
                     />
                   </button>
                 </div>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -5,11 +5,18 @@ import useAxiosInstance from "@hooks/useAxiosInstance";
 import ErrorMsg from "@components/ErrorMsg";
 import { useNavigate } from "react-router-dom";
 import useUserStore from "@store/userStore";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const emailExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 function Signup() {
+  // Dropdown
+  const [isOpen, setIsOpen] = useState(false);
+  const handleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+  const inputFileRef = useRef(null);
+
   const {
     register,
     handleSubmit,
@@ -36,6 +43,7 @@ function Signup() {
 
   const handleFileChange = (e) => {
     const file = e.target.files[0]; // 사용자가 업로드한 파일
+    console.log("handleFileChange:", "실행됨");
     if (file) {
       // 이전 URL 정리
       if (profileImage) {
@@ -145,19 +153,39 @@ function Signup() {
                   <div className="w-full h-full bg-[url('./icons/profile.svg')]"></div>
                 )}
 
-                <div className="absolute bottom-[4px] right-0 rounded-full border border-grey-30 bg-white cursor-pointer">
+                <div className="absolute bottom-[4px] right-0 rounded-full border border-grey-30 bg-white hover:bg-grey-5">
                   <button
                     type="button"
-                    className={`box-border w-12 h-12 ${styles.camera}`}
+                    className={`box-border w-12 h-12 ${styles.camera} `}
+                    onClick={handleOpen}
                   >
-                    <input
-                      type="file"
-                      id="attach"
-                      accept="image/*"
-                      className={`${styles.hidden}`}
-                      {...register("attach")} // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
-                      onChange={handleFileChange}
-                    />
+                    {isOpen && (
+                      <ul className="absolute left-6 top-full mt-1 p-2 shadow rounded-lg flex flex-col gap-[8px] bg-white">
+                        <li
+                          className="flex items-center gap-[10px] p-2 pr-8 hover:bg-sky-100 rounded cursor-pointer"
+                          onClick={() => inputFileRef.current.click()}
+                        >
+                          <i className="fa-solid fa-pen"></i>
+                          <span className="whitespace-nowrap">등록</span>
+                          <input
+                            type="file"
+                            id="attach"
+                            accept="image/*"
+                            className="hidden"
+                            {...register("attach")}
+                            onChange={() => {
+                              console.log("onChange triggered");
+                              handleFileChange();
+                            }}
+                            ref={inputFileRef}
+                          />
+                        </li>
+                        <li className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer">
+                          <i className="fa-regular fa-trash-can"></i>
+                          <span className="whitespace-nowrap">삭제</span>
+                        </li>
+                      </ul>
+                    )}
                   </button>
                 </div>
               </div>

--- a/src/pages/user/Signup.jsx
+++ b/src/pages/user/Signup.jsx
@@ -34,16 +34,19 @@ function Signup() {
       "password-confirm": 11111111,
     },
   });
-  console.log(errors);
 
   const axios = useAxiosInstance();
   const navigate = useNavigate();
   const setUser = useUserStore((store) => store.setUser);
-  const [profileImage, setProfileImage] = useState();
+  const [profileImage, setProfileImage] = useState("");
 
   const handleFileChange = (e) => {
     const file = e.target.files[0]; // 사용자가 업로드한 파일
-    console.log("handleFileChange:", "실행됨");
+    console.log("file: ", file);
+    const watchAll = watch();
+    console.log("watchAll: ", watchAll);
+    console.log("watchAll.attach: ", watchAll.attach);
+
     if (file) {
       // 이전 URL 정리
       if (profileImage) {
@@ -57,12 +60,16 @@ function Signup() {
     }
   };
 
+  const handleDelete = () => {
+    setProfileImage("");
+  };
+
   const registerUser = useMutation({
     mutationFn: async (userInfo) => {
-      console.log("Initial userInfo: ", userInfo); // name, email, password, password-confirm 정보가 담긴 객체
+      console.log("Initial userInfo: ", userInfo); // name, email, password, password-confirm, attach 정보가 담긴 객체
 
       // 프로필 이미지 등록 로직 구현
-      if (userInfo.attach.length > 0) {
+      if (userInfo.attach?.length > 0) {
         const profileFormData = new FormData();
         profileFormData.append("attach", userInfo.attach[0]); // ∵ files API: 첨부 파일 필드명은 attach로 지정해야 한다고 나와있음.
 
@@ -105,7 +112,7 @@ function Signup() {
       console.error(err);
 
       // 클라이언트 측에서 유효성 검사에 실패한 오류를 1차적으로 처리
-      if (err.response.data.errors) {
+      if (err.response?.data.errors) {
         err.reponse.data.errors.forEach(
           (error) => setError(error.path, { message: error.msg })
           // errors 객체를 생성하는 함수 - 객체이기 때문에 키값과 밸류값, 두가지 매개변수를 필요로 함
@@ -167,25 +174,27 @@ function Signup() {
                         >
                           <i className="fa-solid fa-pen"></i>
                           <span className="whitespace-nowrap">등록</span>
-                          <input
-                            type="file"
-                            id="attach"
-                            accept="image/*"
-                            className="hidden"
-                            {...register("attach")}
-                            onChange={() => {
-                              console.log("onChange triggered");
-                              handleFileChange();
-                            }}
-                            ref={inputFileRef}
-                          />
                         </li>
-                        <li className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer">
+                        <li
+                          className="flex items-center gap-[12px] p-2 hover:bg-sky-100 rounded cursor-pointer"
+                          onClick={handleDelete}
+                        >
                           <i className="fa-regular fa-trash-can"></i>
                           <span className="whitespace-nowrap">삭제</span>
                         </li>
                       </ul>
                     )}
+                    <input
+                      type="file"
+                      id="attach"
+                      accept="image/*"
+                      className="hidden"
+                      {...register("attach")}
+                      onChange={(e) => {
+                        handleFileChange(e);
+                      }}
+                      ref={inputFileRef}
+                    />
                   </button>
                 </div>
               </div>

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -52,18 +52,3 @@ img {
 .error:focus-within {
   border: 2px solid #e73434;
 }
-
-.camera {
-  position: relative;
-  background-image: url("/icons/camera.svg");
-  background-repeat: no-repeat;
-  background-position: center;
-}
-
-.hidden {
-  position: absolute;
-  top: 0;
-  right: 0;
-  scale: 1.5;
-  cursor: pointer;
-}

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -52,3 +52,15 @@ img {
 .error:focus-within {
   border: 2px solid #e73434;
 }
+
+.camera {
+  width: 22px;
+  height: 22px;
+  position: relative;
+  background-image: url("/icons/camera.svg");
+  background-repeat: no-repeat;
+  background-position: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -52,3 +52,16 @@ img {
 .error:focus-within {
   border: 2px solid #e73434;
 }
+
+.camera {
+  position: relative;
+  background-image: url("/icons/camera.svg");
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.hidden {
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -58,10 +58,17 @@ img {
   background-image: url("/icons/camera.svg");
   background-repeat: no-repeat;
   background-position: center;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .hidden {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  scale: 1.5;
+  cursor: pointer;
+  z-index: 20;
 }

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -70,5 +70,4 @@ img {
   right: 0;
   scale: 1.5;
   cursor: pointer;
-  z-index: 20;
 }

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -58,10 +58,6 @@ img {
   background-image: url("/icons/camera.svg");
   background-repeat: no-repeat;
   background-position: center;
-  overflow: hidden;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
 .hidden {


### PR DESCRIPTION
## PR 유형

- [✅] 새로운 기능 추가
- [] 버그 수정
- [✅] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [✅] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

- [✅] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [✅] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## PR 상세

### 🛎️ 헤더 UI 변경사항 안내 (menuIcon.jsx) 
> 회원가입 완료 후, 헤더 UI의 개선을 위해 메뉴 아이콘의 배치 순서와 스타일링이 일부 변경되었습니다.
아래 이미지를 통해 확인 부탁드립니다.
<img width="300" alt="image 7" src="https://github.com/user-attachments/assets/77e2ab4a-3e21-42d7-af94-20c50573a5db" />

<img width="322" alt="image 8" src="https://github.com/user-attachments/assets/7d0f465f-e58c-4d15-89b5-83e26fa55545" />

---------------------------------------------------------------------------------------------------

### ☑️  체크리스트

### 1) 회원가입 시 프로필 이미지 등록 기능 추가
> 회원가입 과정에서 프로필 이미지를 등록 및 삭제할 수 있도록 dropdown 기능이 추가되었습니다.

<img width="300" alt="image 10" src="https://github.com/user-attachments/assets/6eb0164e-c14f-460e-a88d-8f58f7bcb9a9" />



👉 등록된 이미지가 정상적으로 표시되는지 확인.
<img width="300" alt="image 2" src="https://github.com/user-attachments/assets/eee2e5e6-7cc6-4790-9274-666ace1691b8" />

👉 삭제 기능이 동작하는지 확인.
<img width="300" alt="image 3" src="https://github.com/user-attachments/assets/cb41757f-c981-4c13-a1e8-49a7a6754072" />
<img width="300" alt="image 4" src="https://github.com/user-attachments/assets/f8088500-a674-46ae-945c-4cd4f3599e5c" />

---------------------------------------------------------------------------------------------------

### 2) 이미지 등록 후 자동 로그인 및 헤더에 프로필 사진 표시
> 프로필 이미지를 등록하고 회원가입 시, 자동 로그인과 함께 헤더에 해당 이미지가 표시됩니다.
> 이미지가 없는 경우, 기본 프로필 사진이 표시되도록 구현하였습니다.

👉 이미지를 등록하고 회원가입 했을 때, 헤더에 해당 프로필사진이 잘 뜨는지 확인.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e314c3fe-c8eb-49ef-9f9a-6f29ff2cc6ae" />

👉 주문조회 페이지에서도 프로필 사진이 잘 뜨는지 확인.
<img width="400" alt="image 5" src="https://github.com/user-attachments/assets/31198aeb-b5fa-44f5-88d2-4b60f575cb0b" />

👉 이미지를 등록하지 않고, 회원가입 했다면 프로필 사진이 뜨지 않음
<img width="400" alt="image 8" src="https://github.com/user-attachments/assets/9480ee9e-100b-4179-a64f-51b458fbbb86" />

👉 주문조회 페이지에서는 기본 프로필 사진으로 떠야함
<img width="400" alt="image 9" src="https://github.com/user-attachments/assets/88801fa2-7d5e-4cb9-9594-db6ff1b7d9f9" />

---------------------------------------------------------------------------------------------------

### 3) 주문조회 페이지에서 로그아웃 시, 메인 페이지로 이동 및 헤더 UI 복구
> 주문조회 페이지에서 로그아웃하면 메인페이지로 이동하며, 헤더의 메뉴 아이콘 배치와 스타일이 초기 상태로 복구됩니다.

<img width="300" alt="image 6" src="https://github.com/user-attachments/assets/bb806091-7faf-4fb1-8ba5-12fd21fd68e0" />

<img width="300" alt="image 7" src="https://github.com/user-attachments/assets/c64adb3c-bc5e-43cf-90f7-06e7a3dccfba" />


## 이슈

resolves #71