### PR TITLE
마이페이지 주문조회 기능 구현 1차 PR

### DIFF
--- a/api/bruno-sample/againSpring/01.회원/01 회원가입,로그인/관리자 로그인(_id=1).bru
+++ b/api/bruno-sample/againSpring/01.회원/01 회원가입,로그인/관리자 로그인(_id=1).bru
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-      "email": "s1@market.com",
+      "email": "admin@market.com",
       "password": "11111111"
   }
 }

--- a/api/bruno-sample/againSpring/01.회원/01 회원가입,로그인/일반 회원 로그인(_id=4).bru
+++ b/api/bruno-sample/againSpring/01.회원/01 회원가입,로그인/일반 회원 로그인(_id=4).bru
@@ -7,7 +7,15 @@ meta {
 post {
   url: {{url}}/users/login
   body: json
-  auth: none
+  auth: bearer
+}
+
+headers {
+  : 
+}
+
+auth:bearer {
+  token: 
 }
 
 body:json {

--- a/src/pages/user/Login.jsx
+++ b/src/pages/user/Login.jsx
@@ -20,7 +20,7 @@ function Login() {
     setError,
     formState: { errors },
   } = useForm({
-    defaultValues: { email: "kimejoa2@market.com", password: "11111111" },
+    defaultValues: { email: "kimejoa@market.com", password: "11111111" },
   });
 
   const login = useMutation({

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -1,10 +1,26 @@
+import useAxiosInstance from "@hooks/useAxiosInstance";
 import OrderBundle from "@pages/user/OrderBundle";
 import Sidebar from "@pages/user/Sidebar";
 import useUserStore from "@store/userStore";
+import { useQuery } from "@tanstack/react-query";
 
 function Myorder() {
+  const axios = useAxiosInstance();
   const { user } = useUserStore();
   console.log(user._id);
+
+  const { data } = useQuery({
+    queryKey: [],
+    queryFn: () => axios.get(`/orders`),
+    select: (res) => {
+      console.log(res.data);
+      return res.data;
+    },
+  });
+
+  const renderedOrderBundle = data?.item.map((bundle) => {
+    return <OrderBundle key={bundle._id} bundle={bundle} />;
+  });
 
   return (
     <>
@@ -41,12 +57,12 @@ function Myorder() {
             </div>
           </div>
 
-          <div className="flex flex-col gap-[20px] p-[20px] text-[26px] font-gowunBold">
+          <div className="flex flex-col gap-[60px] p-[20px] text-[26px] font-gowunBold">
             <div>
               <h1 className="order-list-header">주문 목록</h1>
             </div>
 
-            <OrderBundle />
+            {renderedOrderBundle}
           </div>
         </div>
       </div>

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -44,7 +44,7 @@ function Myorder() {
               <h1 className="order-list-header">주문 목록</h1>
             </div>
 
-            <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px]">
+            <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px] shadow-red-600">
               <div className="flex justify-between items-center">
                 <p className="text-[20px] font-gowunBold">2024.12.25 주문</p>
                 <div className="flex items-center gap-[10px]">
@@ -53,7 +53,7 @@ function Myorder() {
                 </div>
               </div>
 
-              <div className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px]">
+              <div className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px] bg-red-200">
                 <div className="flex justify-between">
                   <div className="text-[20px] font-gowunBold">
                     주문완료

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -57,12 +57,13 @@ function Myorder() {
             </div>
           </div>
 
-          <div className="flex flex-col gap-[60px] p-[20px] text-[26px] font-gowunBold">
+          <div className="flex flex-col p-[20px] text-[26px]">
             <div>
-              <h1 className="order-list-header">주문 목록</h1>
+              <h1 className="mb-8 font-gowunBold">주문 목록</h1>
             </div>
-
-            {renderedOrderBundle}
+            <div className="flex flex-col gap-[50px] text-[26px] font-gowunBold">
+              {renderedOrderBundle}
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -1,3 +1,4 @@
+import Sidebar from "@pages/user/Sidebar";
 import useUserStore from "@store/userStore";
 
 function Myorder() {
@@ -6,15 +7,7 @@ function Myorder() {
   return (
     <>
       <div className="flex box-border max-w-[1200px] mx-auto px-6">
-        <div className="flex flex-col gap-[24px] pt-[24px] min-w-[180px]">
-          <a>주문조회</a>
-          <a>1:1 문의</a>
-          <a>위시리스트</a>
-          <a>쿠폰</a>
-          <a>포인트</a>
-          <a>정보 수정</a>
-          <a>회원탈퇴</a>
-        </div>
+        <Sidebar />
 
         <div className="flex-grow min-w-0 basis-0 flex flex-col gap-[40px]">
           <div className="flex items-center justify-center gap-[30px] box-border p-[30px] overflow-hidden">

--- a/src/pages/user/Myorder.jsx
+++ b/src/pages/user/Myorder.jsx
@@ -1,8 +1,10 @@
+import OrderBundle from "@pages/user/OrderBundle";
 import Sidebar from "@pages/user/Sidebar";
 import useUserStore from "@store/userStore";
 
 function Myorder() {
   const { user } = useUserStore();
+  console.log(user._id);
 
   return (
     <>
@@ -44,36 +46,7 @@ function Myorder() {
               <h1 className="order-list-header">주문 목록</h1>
             </div>
 
-            <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px] shadow-red-600">
-              <div className="flex justify-between items-center">
-                <p className="text-[20px] font-gowunBold">2024.12.25 주문</p>
-                <div className="flex items-center gap-[10px]">
-                  <p className="text-[18px] text-primary-70">주문 상세보기</p>
-                  <img className="w-[30px] h-[30px]" src="/icons/pointer.svg" />
-                </div>
-              </div>
-
-              <div className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px] bg-red-200">
-                <div className="flex justify-between">
-                  <div className="text-[20px] font-gowunBold">
-                    주문완료
-                    <span className="text-[18px] text-secondary-50 font-gowunBold">
-                      {" "}
-                      · 12/30 (목) 도착
-                    </span>
-                  </div>
-                  <img src="/icons/dots.svg" />
-                </div>
-
-                <div className="flex gap-[20px]">
-                  <img src="/icons/image.png" />
-                  <div className="flex flex-col justify-center gap-[20px]">
-                    <p>안티 헤어 로스 샴푸바</p>
-                    <p>12,900원 · 1개</p>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <OrderBundle />
           </div>
         </div>
       </div>

--- a/src/pages/user/Myquery.jsx
+++ b/src/pages/user/Myquery.jsx
@@ -1,16 +1,10 @@
+import Sidebar from "@pages/user/Sidebar";
+
 function Myquery() {
   return (
     <>
       <div className="flex box-border max-w-[1200px] mx-auto px-6 pb-0">
-        <div className="flex flex-col gap-[24px] pt-[24px] min-w-[180px]">
-          <a>주문조회</a>
-          <a>1:1 문의</a>
-          <a>위시리스트</a>
-          <a>쿠폰</a>
-          <a>포인트</a>
-          <a>정보 수정</a>
-          <a>회원탈퇴</a>
-        </div>
+        <Sidebar />
 
         <div className="flex-grow min-w-0 basis-0 flex flex-col gap-[20px]">
           <div className="flex flex-col border-t-2 border-black p-[30px] pb-[40px] items-start justify-center">

--- a/src/pages/user/Myreview.jsx
+++ b/src/pages/user/Myreview.jsx
@@ -1,18 +1,11 @@
+import Sidebar from "@pages/user/Sidebar";
 import styles from "./User.module.css";
 
 function Myreview() {
   return (
     <>
       <div className="flex box-border max-w-[1200px] mx-auto px-6 pb-0">
-        <div className="flex flex-col gap-[24px] pt-[24px] min-w-[180px]">
-          <a>주문조회</a>
-          <a>1:1 문의</a>
-          <a>위시리스트</a>
-          <a>쿠폰</a>
-          <a>포인트</a>
-          <a>정보 수정</a>
-          <a>회원탈퇴</a>
-        </div>
+        <Sidebar />
 
         <div className="flex-grow min-w-0 basis-0 flex flex-col gap-[20px]">
           <div className="flex items-start p-[30px] text-[16px] border-t-2 border-black gap-[18px]">

--- a/src/pages/user/OrderBundle.jsx
+++ b/src/pages/user/OrderBundle.jsx
@@ -12,7 +12,7 @@ OrderBundle.propTypes = {
 function OrderBundle({ bundle }) {
   return (
     <>
-      <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px] shadow-red-600">
+      <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px]">
         <div className="flex justify-between items-center">
           <p className="text-[20px] font-gowunBold">{bundle.createdAt} 주문</p>
           <div className="flex items-center gap-[10px]">

--- a/src/pages/user/OrderBundle.jsx
+++ b/src/pages/user/OrderBundle.jsx
@@ -1,18 +1,27 @@
 import OrderItem from "@pages/user/OrderItem";
+import PropTypes from "prop-types";
 
-function OrderBundle() {
+OrderBundle.propTypes = {
+  bundle: PropTypes.shape({
+    _id: PropTypes.number.isRequired,
+    createdAt: PropTypes.string.isRequired,
+    products: PropTypes.array,
+  }),
+};
+
+function OrderBundle({ bundle }) {
   return (
     <>
       <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px] shadow-red-600">
         <div className="flex justify-between items-center">
-          <p className="text-[20px] font-gowunBold">2024.12.25 주문</p>
+          <p className="text-[20px] font-gowunBold">{bundle.createdAt} 주문</p>
           <div className="flex items-center gap-[10px]">
             <p className="text-[18px] text-primary-70">주문 상세보기</p>
             <img className="w-[30px] h-[30px]" src="/icons/pointer.svg" />
           </div>
         </div>
 
-        <OrderItem />
+        <OrderItem products={bundle.products} />
       </div>
     </>
   );

--- a/src/pages/user/OrderBundle.jsx
+++ b/src/pages/user/OrderBundle.jsx
@@ -1,0 +1,20 @@
+import OrderItem from "@pages/user/OrderItem";
+
+function OrderBundle() {
+  return (
+    <>
+      <div className="flex flex-col rounded-[20px] p-[20px] shadow-[rgba(0,0,0,0.08)_0px_2px_4px_0px,_rgba(0,0,0,0.16)_0px_0px_1px_0px] shadow-red-600">
+        <div className="flex justify-between items-center">
+          <p className="text-[20px] font-gowunBold">2024.12.25 주문</p>
+          <div className="flex items-center gap-[10px]">
+            <p className="text-[18px] text-primary-70">주문 상세보기</p>
+            <img className="w-[30px] h-[30px]" src="/icons/pointer.svg" />
+          </div>
+        </div>
+
+        <OrderItem />
+      </div>
+    </>
+  );
+}
+export default OrderBundle;

--- a/src/pages/user/OrderItem.jsx
+++ b/src/pages/user/OrderItem.jsx
@@ -1,0 +1,28 @@
+function OrderItem() {
+  return (
+    <>
+      <div className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px] bg-red-200">
+        <div className="flex justify-between">
+          <div className="text-[20px] font-gowunBold">
+            주문완료
+            <span className="text-[18px] text-secondary-50 font-gowunBold">
+              {" "}
+              · 12/30 (목) 도착
+            </span>
+          </div>
+          <img src="/icons/dots.svg" />
+        </div>
+
+        <div className="flex gap-[20px]">
+          <img src="/icons/image.png" />
+          <div className="flex flex-col justify-center gap-[20px]">
+            <p>안티 헤어 로스 샴푸바</p>
+            <p>12,900원 · 1개</p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default OrderItem;

--- a/src/pages/user/OrderItem.jsx
+++ b/src/pages/user/OrderItem.jsx
@@ -1,10 +1,13 @@
 import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
 
 OrderItem.propTypes = {
   products: PropTypes.array,
 };
 
 function OrderItem({ products }) {
+  const navigate = useNavigate();
+
   const renderedItem = products.map((item) => {
     return (
       <div
@@ -13,7 +16,7 @@ function OrderItem({ products }) {
       >
         <div className="flex flex-col flex-grow justify-center p-[24px]">
           <div className="flex justify-between">
-            <div className="text-[24px] font-gowunBold">
+            <div className="text-[20px] font-gowunBold">
               주문완료
               <span className="text-[18px] text-secondary-50 font-gowunBold">
                 {" "}
@@ -28,8 +31,8 @@ function OrderItem({ products }) {
               src={`https://11.fesp.shop${item.image?.path}`}
             />
             <div className="flex flex-col justify-center gap-[20px]">
-              <p className="text-[20px]">{item.name}</p>
-              <p className="text-[20px]">
+              <p className="text-[18px]">{item.name}</p>
+              <p className="text-[18px]">
                 {item.price.toLocaleString()}원 · {item.quantity}개
               </p>
             </div>
@@ -39,19 +42,20 @@ function OrderItem({ products }) {
         <div className="flex flex-col justify-center gap-[20px] w-[240px] p-[24px] border-l border-grey-20">
           <button
             type="button"
-            className="text-[18px] border border-grey-20 h-[48px] rounded-lg"
+            className="text-[16px] border border-grey-20 h-[46px] rounded-lg"
           >
             배송 조회
           </button>
           <button
             type="button"
-            className="text-[18px] border border-grey-20 h-[48px] rounded-lg"
+            className="text-[16px] border border-grey-20 h-[46px] rounded-lg"
           >
             교환, 반품 신청
           </button>
           <button
             type="button"
-            className="text-[18px] text-primary-60 border border-primary-60 h-[48px] rounded-lg"
+            className="text-[16px] text-primary-60 border border-primary-60 h-[46px] rounded-lg"
+            onClick={() => navigate("/review")}
           >
             리뷰 작성하기
           </button>

--- a/src/pages/user/OrderItem.jsx
+++ b/src/pages/user/OrderItem.jsx
@@ -9,21 +9,20 @@ function OrderItem({ products }) {
     return (
       <div
         key={item._id}
-        className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px] "
+        className="mt-[30px] flex gap-[20px] text-[16px] border border-grey-10 rounded-[12px] "
       >
-        <div className="flex justify-between">
-          <div className="text-[24px] font-gowunBold">
-            주문완료
-            <span className="text-[18px] text-secondary-50 font-gowunBold">
-              {" "}
-              · 12/30 (목) 도착
-            </span>
+        <div className="flex flex-col flex-grow justify-center p-[24px]">
+          <div className="flex justify-between">
+            <div className="text-[24px] font-gowunBold">
+              주문완료
+              <span className="text-[18px] text-secondary-50 font-gowunBold">
+                {" "}
+                · 12/30 (목) 도착
+              </span>
+            </div>
+            <img src={"/icons/dots.svg"} />
           </div>
-          <img src={"/icons/dots.svg"} />
-        </div>
-
-        <div className="flex items-center border border-primary-50 rounded-lg">
-          <div className="flex flex-grow gap-[20px]">
+          <div className="flex gap-[20px]">
             <img
               className="w-[150px] h-[200px] object-contain"
               src={`https://11.fesp.shop${item.image?.path}`}
@@ -35,26 +34,27 @@ function OrderItem({ products }) {
               </p>
             </div>
           </div>
-          <div className="flex flex-col gap-[20px] w-[240px] p-[20px] border-l border-grey-30">
-            <button
-              type="button"
-              className="text-[18px] border border-grey-20 h-[48px]"
-            >
-              배송 조회
-            </button>
-            <button
-              type="button"
-              className="text-[18px] border border-grey-20 h-[48px]"
-            >
-              교환, 반품 신청
-            </button>
-            <button
-              type="button"
-              className="text-[18px] text-primary-60 border border-primary-60 h-[48px]"
-            >
-              리뷰 작성하기
-            </button>
-          </div>
+        </div>
+
+        <div className="flex flex-col justify-center gap-[20px] w-[240px] p-[24px] border-l border-grey-20">
+          <button
+            type="button"
+            className="text-[18px] border border-grey-20 h-[48px] rounded-lg"
+          >
+            배송 조회
+          </button>
+          <button
+            type="button"
+            className="text-[18px] border border-grey-20 h-[48px] rounded-lg"
+          >
+            교환, 반품 신청
+          </button>
+          <button
+            type="button"
+            className="text-[18px] text-primary-60 border border-primary-60 h-[48px] rounded-lg"
+          >
+            리뷰 작성하기
+          </button>
         </div>
       </div>
     );

--- a/src/pages/user/OrderItem.jsx
+++ b/src/pages/user/OrderItem.jsx
@@ -12,7 +12,7 @@ function OrderItem({ products }) {
     return (
       <div
         key={item._id}
-        className="mt-[30px] flex text-[16px] border border-grey-10 rounded-[12px] "
+        className="mt-[30px] flex text-[16px] border border-grey-30 rounded-[12px] "
       >
         <div className="flex flex-col flex-grow justify-center p-[24px]">
           <div className="flex justify-between">
@@ -39,7 +39,7 @@ function OrderItem({ products }) {
           </div>
         </div>
 
-        <div className="flex flex-col justify-center gap-[20px] w-[240px] p-[24px] border-l border-grey-20">
+        <div className="flex flex-col justify-center gap-[20px] w-[240px] p-[24px] border-l border-grey-30">
           <button
             type="button"
             className="text-[16px] border border-grey-20 h-[46px] rounded-lg"

--- a/src/pages/user/OrderItem.jsx
+++ b/src/pages/user/OrderItem.jsx
@@ -1,28 +1,65 @@
-function OrderItem() {
-  return (
-    <>
-      <div className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px] bg-red-200">
+import PropTypes from "prop-types";
+
+OrderItem.propTypes = {
+  products: PropTypes.array,
+};
+
+function OrderItem({ products }) {
+  const renderedItem = products.map((item) => {
+    return (
+      <div
+        key={item._id}
+        className="mt-[30px] flex flex-col gap-[20px] text-[16px] border border-grey-10 rounded-[12px] p-[20px] "
+      >
         <div className="flex justify-between">
-          <div className="text-[20px] font-gowunBold">
+          <div className="text-[24px] font-gowunBold">
             주문완료
             <span className="text-[18px] text-secondary-50 font-gowunBold">
               {" "}
               · 12/30 (목) 도착
             </span>
           </div>
-          <img src="/icons/dots.svg" />
+          <img src={"/icons/dots.svg"} />
         </div>
 
-        <div className="flex gap-[20px]">
-          <img src="/icons/image.png" />
-          <div className="flex flex-col justify-center gap-[20px]">
-            <p>안티 헤어 로스 샴푸바</p>
-            <p>12,900원 · 1개</p>
+        <div className="flex items-center border border-primary-50 rounded-lg">
+          <div className="flex flex-grow gap-[20px]">
+            <img
+              className="w-[150px] h-[200px] object-contain"
+              src={`https://11.fesp.shop${item.image?.path}`}
+            />
+            <div className="flex flex-col justify-center gap-[20px]">
+              <p className="text-[20px]">{item.name}</p>
+              <p className="text-[20px]">
+                {item.price.toLocaleString()}원 · {item.quantity}개
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-[20px] w-[240px] p-[20px] border-l border-grey-30">
+            <button
+              type="button"
+              className="text-[18px] border border-grey-20 h-[48px]"
+            >
+              배송 조회
+            </button>
+            <button
+              type="button"
+              className="text-[18px] border border-grey-20 h-[48px]"
+            >
+              교환, 반품 신청
+            </button>
+            <button
+              type="button"
+              className="text-[18px] text-primary-60 border border-primary-60 h-[48px]"
+            >
+              리뷰 작성하기
+            </button>
           </div>
         </div>
       </div>
-    </>
-  );
+    );
+  });
+  return <>{renderedItem}</>;
 }
 
 export default OrderItem;

--- a/src/pages/user/OrderItem.jsx
+++ b/src/pages/user/OrderItem.jsx
@@ -9,7 +9,7 @@ function OrderItem({ products }) {
     return (
       <div
         key={item._id}
-        className="mt-[30px] flex gap-[20px] text-[16px] border border-grey-10 rounded-[12px] "
+        className="mt-[30px] flex text-[16px] border border-grey-10 rounded-[12px] "
       >
         <div className="flex flex-col flex-grow justify-center p-[24px]">
           <div className="flex justify-between">

--- a/src/pages/user/Sidebar.jsx
+++ b/src/pages/user/Sidebar.jsx
@@ -1,10 +1,8 @@
 import { Link } from "react-router-dom";
-import { useEffect, useState } from "react";
 import styles from "./User.module.css";
 
 function Sidebar() {
-  const [currentPath, setCurrentPath] = useState(window.location.pathname);
-  console.log(currentPath);
+  const currentPath = window.location.pathname;
 
   const links = [
     { label: "주문조회", path: "/order" },

--- a/src/pages/user/Sidebar.jsx
+++ b/src/pages/user/Sidebar.jsx
@@ -1,6 +1,11 @@
 import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import styles from "./User.module.css";
 
 function Sidebar() {
+  const [currentPath, setCurrentPath] = useState(window.location.pathname);
+  console.log(currentPath);
+
   const links = [
     { label: "주문조회", path: "/order" },
     { label: "1:1 문의", path: "/query" },
@@ -13,7 +18,11 @@ function Sidebar() {
 
   const renderedLinks = links.map((link) => {
     return (
-      <Link key={link.label} to={link.path} className="mb-1">
+      <Link
+        key={link.label}
+        to={link.path}
+        className={`mb-2 ${currentPath === link.path ? styles.active : ""}`}
+      >
         {link.label}
       </Link>
     );

--- a/src/pages/user/Sidebar.jsx
+++ b/src/pages/user/Sidebar.jsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+
+function Sidebar() {
+  const links = [
+    { label: "주문조회", path: "/order" },
+    { label: "1:1 문의", path: "/query" },
+    { label: "위시리스트", path: "/uncompleted" },
+    { label: "쿠폰", path: "/uncompleted" },
+    { label: "포인트", path: "/uncompleted" },
+    { label: "정보수정", path: "/uncompleted" },
+    { label: "회원탈퇴", path: "/uncompleted" },
+  ];
+
+  const renderedLinks = links.map((link) => {
+    return (
+      <Link key={link.label} to={link.path} className="mb-1">
+        {link.label}
+      </Link>
+    );
+  });
+
+  return (
+    <>
+      <div className="flex flex-col items-start gap-[24px] pt-[24px] min-w-[180px]">
+        {renderedLinks}
+      </div>
+    </>
+  );
+}
+
+export default Sidebar;

--- a/src/pages/user/UncompletedPage.jsx
+++ b/src/pages/user/UncompletedPage.jsx
@@ -1,0 +1,16 @@
+import Sidebar from "@pages/user/Sidebar";
+
+function UncompletedPage() {
+  return (
+    <>
+      <div className="flex box-border max-w-[1200px] mx-auto px-6">
+        <Sidebar />
+        <div className="flex grow basis-0 min-w-0 justify-center items-center">
+          ⏰ 준비중입니다...
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default UncompletedPage;

--- a/src/pages/user/User.module.css
+++ b/src/pages/user/User.module.css
@@ -64,3 +64,7 @@ img {
   justify-content: center;
   align-items: center;
 }
+
+.active {
+  @apply border-l-8 border-primary-40 pl-4 font-gowunBold;
+}

--- a/src/routes/homeRoutes.jsx
+++ b/src/routes/homeRoutes.jsx
@@ -23,7 +23,8 @@ import Cart from "@pages/Cart";
 import EventMainPage from "@pages/eventPage/EventMainPage";
 import EventDetailPage from "@pages/eventPage/EventDetailPage";
 import TansoPage from "@pages/tanso/tanso-main";
-import SearchPage from '@pages/SearchPage';
+import SearchPage from "@pages/SearchPage";
+import UncompletedPage from "@pages/user/UncompletedPage";
 
 const homeRoutes = [
   {
@@ -62,6 +63,7 @@ const homeRoutes = [
       { path: "tanso", element: <TansoPage /> },
       { path: "cart/:userId", element: <Cart /> },
       { path: "/search", element: <SearchPage /> },
+      { path: "/uncompleted", element: <UncompletedPage /> },
     ],
   },
 ];

--- a/src/utils/kakaoUtils.js
+++ b/src/utils/kakaoUtils.js
@@ -1,0 +1,16 @@
+export const KAKAO_url = "https://kauth.kakao.com/oauth/authorize";
+export const API_KEY = "7b635f7b3d4379252462f78787fc908b";
+export const REDIRECT_URI = "http://localhost:5173/users/login/kakao";
+
+// handleKakaoLogin 함수는 같은 파일에 있는 KAKAO_url, API_KEY, REDIRECT_URI를 참조
+// 이 참조는 **파일 레벨에서의 스코프(scope)**로 동작하므로, 변수들을 따로 import하지 않아도 함수 내부에서 사용할 수 있습니다.
+export const handleKakaoLogin = () => {
+  window.location.href = `${KAKAO_url}?client_id=${API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code&state=auto`;
+};
+
+// ❓ Login.jsx에서 handleKakaoLogin 함수만 import해서 사용하는데, 해당 함수 내부에서 참조하는 변수들(KAKAO_url, API_KEY, REDIRECT_URI)을 따로 import하지 않아도 정상적으로 작동하는 이유는 무엇인가요?
+
+// => 현재 구조에서는 handleKakaoLogin 함수가 kakaoUtils 파일에서 제대로 작동합니다. 이유는 JavaScript에서 함수 내에서 사용되는 변수(KAKAO_url, API_KEY, REDIRECT_URI)가 같은 파일에서 정의되어 있고, 함수 내부에서 그 변수들을 참조하기 때문입니다.
+
+// 왜 작동하는지?
+// handleKakaoLogin 함수는 클로저(closure)의 개념을 사용합니다. 함수가 정의될 때, 함수 내부에서 참조하는 변수(KAKAO_url, API_KEY, REDIRECT_URI)는 함수와 함께 메모리에 저장됩니다. 따라서 이 변수들이 함수 내에서 정상적으로 접근 가능합니다.


### PR DESCRIPTION
## PR 유형

- [✅] 새로운 기능 추가
- [] 버그 수정
- [✅] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [✅] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

- [✅] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [✅] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

☑️  체크리스트
1️⃣ 현재 경로와 클릭한 사이드바 메뉴가 같으면 왼쪽 연두색 보더가 생성되도록 스타일링을 수정하였습니다.
2️⃣ 주문목록 UI의 전체적인 레이아웃 구조와 스타일링을 수정하였습니다.
3️⃣ u1@market.com (제이지)로 로그인시, 현재 DB에 있는 order 목록들의 제품들이 컴포넌트 계층구조에 맞게 렌더링되도록 하였습니다.

✏️ 디테일한 수정
1. 12/30 (목) 도착 -> 하드코딩된 부분입니다. 추후 수정할 예정.
2. 주문 일자 -> 깔끔하게 수정할 예정.

## > 주문조회 페이지
![image](https://github.com/user-attachments/assets/dcf9bdf4-6dfd-478b-9083-236653775be1)

## > 1:1 문의 페이지
![image](https://github.com/user-attachments/assets/e81731fa-ca13-4826-8575-4ffae34bb762)

## 이슈

resolves #104
