### PR TITLE
🔒️ [Q&A] 답변 상태 표시할 관리자 이메일 추가

### DIFF
--- a/src/components/PostDetail.jsx
+++ b/src/components/PostDetail.jsx
@@ -12,6 +12,9 @@ import PropTypes from 'prop-types';
  * @param {string} type - 게시글 타입 (notice 또는 qna)
  */
 export default function PostDetail({ type = 'notice' }) {
+  // 관리자 이메일 배열 정의
+  const ADMIN_EMAILS = ['admin@market.com', 'seop96@naver.com'];
+
   const { id } = useParams();
   const { user } = useUserStore();
   const axios = useAxiosInstance();
@@ -85,11 +88,12 @@ export default function PostDetail({ type = 'notice' }) {
           mainImages: data.item.product.mainImages[0],
         });
       }
+
       // 답변 상태 설정
       if (data.item?.replies) {
         setReplies(data.item.replies);
-        const adminReplyExists = data.item.replies.some(
-          (reply) => reply.user?.email === 'admin@market.com'
+        const adminReplyExists = data.item.replies.some((reply) =>
+          ADMIN_EMAILS.includes(reply.user?.email)
         );
         setHasAdminReply(adminReplyExists);
       }

--- a/src/pages/qna/QnAListItem.jsx
+++ b/src/pages/qna/QnAListItem.jsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import useAxiosInstance from '@hooks/useAxiosInstance';
 
 const QnAListItem = ({ item, number }) => {
+  const ADMIN_EMAILS = ['admin@market.com', 'seop96@naver.com'];
+
   const axios = useAxiosInstance();
 
   const { data: repliesData } = useQuery({
@@ -14,8 +16,8 @@ const QnAListItem = ({ item, number }) => {
     cacheTime: 1000 * 60 * 5,
   });
 
-  const hasAdminReply = repliesData?.item?.some(
-    (reply) => reply.user?.email === 'admin@market.com'
+  const hasAdminReply = repliesData?.item?.some((reply) =>
+    ADMIN_EMAILS.includes(reply.user?.email)
   );
 
   return (


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
시연(테스트) 때 사용할 관리자 이메일이 seop96@naver.com 이라고 적혀있지만
![image](https://github.com/user-attachments/assets/046406a2-a9f2-4f63-b5d5-aa1c45e0ab6f)

관리자 답변 상태를 확인 하는 이메일이  admin@market.com 밖에 없었는데요.
![image](https://github.com/user-attachments/assets/b6f6bd25-4cd2-4a1a-ab7d-df1f20b7f014)
(이메일로 지정한 이유는 본문에서는 user의 type을 반환하고 있지 않아서 이메일로 지정..)
![image](https://github.com/user-attachments/assets/203f1fe4-1ed5-4a5b-b449-141083a99ce4)


그래서 seop96@naver.com 으로 로그인해도 코드에 해당 이메일을 추가하지 않았기에
답변 상태가 추적이 안 되는 문제점이 있었습니다.
![image](https://github.com/user-attachments/assets/b36d2c5f-76c2-4e96-9570-d830e11be7fd)

결론적으로 기존 코드에 seop96@naver.com 이메일을 추가했습니다.
![image](https://github.com/user-attachments/assets/97d5faf2-db20-467a-a7ab-ee8227f760df)

seop96@naver.com으로 로그인해서 답변을 달면 답변상태 추적 가능합니다.
![image](https://github.com/user-attachments/assets/af127a53-0139-4065-8d37-b38fea3fa785)
## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #139 